### PR TITLE
Export `VideoUploadResponse`

### DIFF
--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -1,3 +1,3 @@
 export { UploadProgressEvent, VideoUploader, VideoUploaderOptionsWithAccessToken, VideoUploaderOptionsWithUploadToken } from "./video-uploader";
 export { ProgressiveUploadProgressEvent, ProgressiveUploader, ProgressiveUploaderOptionsWithAccessToken, ProgressiveUploaderOptionsWithUploadToken } from './progressive-video-uploader';
-export { MIN_CHUNK_SIZE, MAX_CHUNK_SIZE } from './common';
+export { VideoUploadResponse, MIN_CHUNK_SIZE, MAX_CHUNK_SIZE } from './common';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { UploadProgressEvent, VideoUploader, VideoUploaderOptionsWithAccessToken, VideoUploaderOptionsWithUploadToken } from "./video-uploader";
 export { ProgressiveUploadProgressEvent, ProgressiveUploader, ProgressiveUploaderOptionsWithAccessToken, ProgressiveUploaderOptionsWithUploadToken } from './progressive-video-uploader';
-export { MIN_CHUNK_SIZE, MAX_CHUNK_SIZE } from './common';
+export { VideoUploadResponse, MIN_CHUNK_SIZE, MAX_CHUNK_SIZE } from './common';


### PR DESCRIPTION
Hi,

I'm attempting to work with the `ApiVideoMediaRecorder` with TypeScript. Something of a nuisance in the current recorder API is that the `stop` method returns `Promise<unknown>`: https://github.com/apivideo/api.video-typescript-media-recorder/blob/ddf244216b0228a87d22e3abc18085b8388f8a45/dist/src/index.d.ts#L14

Looking at the code, it seems that in fact it is known to be `VideoUploadResponse`, and I plan to open a PR on `apivideo/api.video-typescript-media-recorder` with that change, but to do so the `VideoUploadResponse` type needs to be exported.

Hopefully this is a reasonable thing to do! Let me know if you'd prefer a different approach.

---

- 88190e0 **Export `VideoUploadResponse`**

  This type is a key part of the API, so its useful for it to be exported
  in the package's types.
