### PR TITLE
Feat/custom video name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All changes to this project will be documented in this file.
 
-## [1.1] - 2022-07-06
+## [1.1.0] - 2022-07-06
 - Video upload & Progressive upload: allow user to set a customized video name.
 
 ## [1.0.11] - 2022-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 All changes to this project will be documented in this file.
 
+## [1.1] - 2022-07-06
+- Video upload & Progressive upload: allow user to set a customized video name.
+
 ## [1.0.11] - 2022-07-06
 - Add origin headers
-- 
+
 ## [1.0.10] - 2022-06-29
 - Retry even if the server is not responding.
 - Add possibility to define a custom retry policy.

--- a/README.md
+++ b/README.md
@@ -178,13 +178,14 @@ Using delegated upload tokens for authentication is best options when uploading 
 #### Common options
 
 
-|   Option name | Mandatory | Type                                                            | Description                                                                                                   |
-| ------------: | --------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-|          file | **yes**   | File                                                            | the file you want to upload                                                                                   |
-|     chunkSize | no        | number                                                          | number of bytes of each upload chunk (default: 50MB, min: 5MB, max: 128MB)                                    |
-|       apiHost | no        | string                                                          | api.video host (default: ws.api.video)                                                                        |
-|       retries | no        | number                                                          | number of retries when an API call fails (default: 5)                                                         |
-| retryStrategy | no        | (retryCount: number, error: VideoUploadError) => number \| null | function that returns the number of ms to wait before retrying a failed upload. Returns null to stop retrying |
+|   Option name | Mandatory | Type                                                            | Description                                                                                                                              |
+| ------------: | --------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+|          file | **yes**   | File                                                            | the file you want to upload                                                                                                              |
+|     videoName | no        | string                                                          | the name of your video (overrides the original file name for regular uploads, overrides the default "file" name for progressive uploads) |
+|     chunkSize | no        | number                                                          | number of bytes of each upload chunk (default: 50MB, min: 5MB, max: 128MB)                                                               |
+|       apiHost | no        | string                                                          | api.video host (default: ws.api.video)                                                                                                   |
+|       retries | no        | number                                                          | number of retries when an API call fails (default: 5)                                                                                    |
+| retryStrategy | no        | (retryCount: number, error: VideoUploadError) => number \| null | function that returns the number of ms to wait before retrying a failed upload. Returns null to stop retrying                            |
 
 
 ### Example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.video/video-uploader",
-  "version": "1.0.11",
+  "version": "1.1",
   "description": "api.video video uploader",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.video/video-uploader",
-  "version": "1.1",
+  "version": "1.1.0",
   "description": "api.video video uploader",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "tslint": "tslint --project .",
     "build": "npm run tslint && webpack --mode production",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && mocha -r ts-node/register -r jsdom-global/register 'test/**/*.ts'"
+    "test": "npm run build && mocha -r ts-node/register -r jsdom-global/register 'test/**/*.ts'",
+    "watch": "npx webpack --watch --mode=development"
   }, 
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/sample/index.html
+++ b/sample/index.html
@@ -8,12 +8,15 @@
 
     <form>
         <input type="file" id="input" onchange="uploadFile(this.files)">
+        <input type="text" id="VideoName" placeholder="Video name">
     </form>
     <script type="text/javascript">
         function uploadFile(files) {
+            const videoName = document.getElementById('VideoName').value
             const uploader = new VideoUploader({
                 file: files[0],
-                uploadToken: "to7EcLLzRSsqhkzxyIhavEHA" // ecosystem sandbox upload token
+                uploadToken: "to7EcLLzRSsqhkzxyIhavEHA", // ecosystem sandbox upload token
+                videoName: videoName
             });
 
             uploader.upload()

--- a/src/abstract-uploader.ts
+++ b/src/abstract-uploader.ts
@@ -41,6 +41,7 @@ interface Origin {
 export interface CommonOptions {
     apiHost?: string;
     retries?: number;
+    videoName?: string;
     retryStrategy?: RetryStrategy;
     origin?: {
         application?: Origin;

--- a/src/progressive-video-uploader.ts
+++ b/src/progressive-video-uploader.ts
@@ -3,6 +3,7 @@ import { PromiseQueue } from "./promise-queue";
 
 export interface ProgressiveUploadCommonOptions {
     preventEmptyParts?: boolean;
+    videoName?: string
 }
 
 export interface ProgressiveUploaderOptionsWithUploadToken extends ProgressiveUploadCommonOptions, CommonOptions, WithUploadToken { }
@@ -25,10 +26,12 @@ export class ProgressiveUploader extends AbstractUploader<ProgressiveProgressEve
     private currentPartBlobsSize = 0;
     private queue = new PromiseQueue();
     private preventEmptyParts: boolean;
+    private fileName: string;
 
     constructor(options: ProgressiveUploaderOptionsWithAccessToken | ProgressiveUploaderOptionsWithUploadToken | ProgressiveUploaderOptionsWithApiKey) {
         super(options);
         this.preventEmptyParts = options.preventEmptyParts || false;
+        this.fileName = options.videoName || 'file';
     }
 
     public uploadPart(file: Blob): Promise<void> {
@@ -71,7 +74,7 @@ export class ProgressiveUploader extends AbstractUploader<ProgressiveProgressEve
     private async upload(file: Blob, isLast: boolean = false): Promise<VideoUploadResponse> {
         const fileSize = file.size;
         return this.xhrWithRetrier({
-            body: this.createFormData(file, "file"),
+            body: this.createFormData(file, this.fileName),
             parts: {
                 currentPart: this.currentPartNum,
                 totalParts: isLast ? this.currentPartNum : '*'

--- a/src/progressive-video-uploader.ts
+++ b/src/progressive-video-uploader.ts
@@ -3,7 +3,6 @@ import { PromiseQueue } from "./promise-queue";
 
 export interface ProgressiveUploadCommonOptions {
     preventEmptyParts?: boolean;
-    videoName?: string
 }
 
 export interface ProgressiveUploaderOptionsWithUploadToken extends ProgressiveUploadCommonOptions, CommonOptions, WithUploadToken { }

--- a/src/video-uploader.ts
+++ b/src/video-uploader.ts
@@ -2,7 +2,6 @@ import { AbstractUploader, CommonOptions, DEFAULT_CHUNK_SIZE, MAX_CHUNK_SIZE, MI
 
 interface UploadOptions {
     file: File;
-    videoName?: string;
     chunkSize?: number;
 }
 

--- a/src/video-uploader.ts
+++ b/src/video-uploader.ts
@@ -2,6 +2,7 @@ import { AbstractUploader, CommonOptions, DEFAULT_CHUNK_SIZE, MAX_CHUNK_SIZE, MI
 
 interface UploadOptions {
     file: File;
+    videoName?: string;
     chunkSize?: number;
 }
 
@@ -39,7 +40,7 @@ export class VideoUploader extends AbstractUploader<UploadProgressEvent> {
         this.chunkSize = options.chunkSize || DEFAULT_CHUNK_SIZE;
         this.file = options.file;
         this.fileSize = this.file.size;
-        this.fileName = this.file.name;
+        this.fileName = options.videoName || this.file.name;
 
         this.chunksCount = Math.ceil(this.fileSize / this.chunkSize);
     }

--- a/test/video-uploader.test.ts
+++ b/test/video-uploader.test.ts
@@ -23,20 +23,6 @@ describe('Instanciation', () => {
             chunkSize: 1024 * 1024 * 1
         })).to.throw("Invalid chunk size. Minimal allowed value: 5MB, maximum allowed value: 128MB.");
     });
-
-    it ('video name is file name', (done) => {
-        const uploadToken = "the-upload-token";
-
-        const uploader = new VideoUploader({
-            file: new File([new ArrayBuffer(10)], "filename"),
-            uploadToken,
-        });
-
-        uploader.upload().then(res => {
-            expect(res.title).to.be.eq("filename");
-            done();
-        });
-    })
 });
 
 describe('Content-range', () => {
@@ -211,6 +197,46 @@ describe('Delegated upload', () => {
 
         uploader.upload().then(() => done());
     });
+
+    it('video name is file name', (done) => {
+        const uploadToken = "the-upload-token";
+        const videoId = "9876";
+        const fileName = "filename"
+
+        const uploader = new VideoUploader({
+            file: new File([new ArrayBuffer(10)], fileName),
+            uploadToken,
+            videoId
+        });
+
+        mock.post(`https://ws.api.video/upload?token=${uploadToken}`, (req, res) => {
+            expect(req.body().get("file").name).to.be.eql(fileName);
+            return res.status(201).body("{}");
+        });
+
+        uploader.upload().then(() => done());
+    })
+
+    it('video name is customized', (done) => {
+        const uploadToken = "the-upload-token";
+        const videoId = "9876";
+        const fileName = "filename"
+        const videoName = "video name"
+
+        const uploader = new VideoUploader({
+            file: new File([new ArrayBuffer(10)], fileName),
+            uploadToken,
+            videoId,
+            videoName
+        });
+
+        mock.post(`https://ws.api.video/upload?token=${uploadToken}`, (req, res) => {
+            expect(req.body().get("file").name).to.be.eql(videoName);
+            return res.status(201).body("{}");
+        });
+
+        uploader.upload().then(() => done());
+    })
 });
 
 describe('Progress listener', () => {

--- a/test/video-uploader.test.ts
+++ b/test/video-uploader.test.ts
@@ -23,6 +23,20 @@ describe('Instanciation', () => {
             chunkSize: 1024 * 1024 * 1
         })).to.throw("Invalid chunk size. Minimal allowed value: 5MB, maximum allowed value: 128MB.");
     });
+
+    it ('video name is file name', (done) => {
+        const uploadToken = "the-upload-token";
+
+        const uploader = new VideoUploader({
+            file: new File([new ArrayBuffer(10)], "filename"),
+            uploadToken,
+        });
+
+        uploader.upload().then(res => {
+            expect(res.title).to.be.eq("filename");
+            done();
+        });
+    })
 });
 
 describe('Content-range', () => {


### PR DESCRIPTION
### Issue

We were not able to customize the video name when uploaded with the TS uploader

### Description of the Change

Add specific `videoName` field in both `VideoUploader` & `ProgressiveUploader` to allow the user to customize his file name.

### Possible Drawbacks

- The `VideoUploader` and `ProgressiveUploader` can't upload a video anymore
- Custom name is not taken in account

### Verification Process

- **VideoUploader:** Run the sample app and try to set a custom name in the text field
- **ProgressiveUploader:** Run the [api.video-typescript-media-recorder](https://github.com/apivideo/api.video-typescript-media-recorder) sample app and set a custom name in the text field

### Release Notes

Allow user to customize the uploaded file name.