### PR TITLE
feat: Add mergeSmallPartsBeforeUpload option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.video/video-uploader",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "api.video video uploader",
   "repository": {
     "type": "git",

--- a/src/progressive-video-uploader.ts
+++ b/src/progressive-video-uploader.ts
@@ -37,6 +37,9 @@ export class ProgressiveUploader extends AbstractUploader<ProgressiveProgressEve
     }
 
     public uploadPart(file: Blob): Promise<void> {
+        if (!this.mergeSmallPartsBeforeUpload && file.size < MIN_CHUNK_SIZE) {
+            throw new Error(`Each part must have a minimal size of 5MB. The current part has a size of ${this.currentPartBlobsSize / 1024 / 1024}MB.`)
+        }
         this.currentPartBlobsSize += file.size;
         this.currentPartBlobs.push(file);
 
@@ -44,9 +47,6 @@ export class ProgressiveUploader extends AbstractUploader<ProgressiveProgressEve
             || (!this.preventEmptyParts && (this.currentPartBlobsSize >= MIN_CHUNK_SIZE))
             || (!this.mergeSmallPartsBeforeUpload)) {
 
-            if (!this.mergeSmallPartsBeforeUpload && this.currentPartBlobsSize < MIN_CHUNK_SIZE) {
-                throw new Error(`Each part must have a minimal size of 5MB. The current part has a size of ${this.currentPartBlobsSize / 1024 / 1024}MB.`)
-            }
             let toSend: any[];
             if(this.preventEmptyParts) {
                 toSend = this.currentPartBlobs.slice(0, -1);

--- a/src/progressive-video-uploader.ts
+++ b/src/progressive-video-uploader.ts
@@ -3,6 +3,7 @@ import { PromiseQueue } from "./promise-queue";
 
 export interface ProgressiveUploadCommonOptions {
     preventEmptyParts?: boolean;
+    mergeSmallPartsBeforeUpload?: boolean;
 }
 
 export interface ProgressiveUploaderOptionsWithUploadToken extends ProgressiveUploadCommonOptions, CommonOptions, WithUploadToken { }
@@ -26,11 +27,13 @@ export class ProgressiveUploader extends AbstractUploader<ProgressiveProgressEve
     private queue = new PromiseQueue();
     private preventEmptyParts: boolean;
     private fileName: string;
+    private mergeSmallPartsBeforeUpload: boolean;
 
     constructor(options: ProgressiveUploaderOptionsWithAccessToken | ProgressiveUploaderOptionsWithUploadToken | ProgressiveUploaderOptionsWithApiKey) {
         super(options);
         this.preventEmptyParts = options.preventEmptyParts || false;
         this.fileName = options.videoName || 'file';
+        this.mergeSmallPartsBeforeUpload = options.mergeSmallPartsBeforeUpload ?? true;
     }
 
     public uploadPart(file: Blob): Promise<void> {
@@ -38,8 +41,8 @@ export class ProgressiveUploader extends AbstractUploader<ProgressiveProgressEve
         this.currentPartBlobs.push(file);
 
         if ((this.preventEmptyParts && (this.currentPartBlobsSize - file.size >= MIN_CHUNK_SIZE))
-            || (!this.preventEmptyParts && (this.currentPartBlobsSize >= MIN_CHUNK_SIZE))) {
-
+            || (!this.preventEmptyParts && (this.currentPartBlobsSize >= MIN_CHUNK_SIZE))
+            || (!this.mergeSmallPartsBeforeUpload)) {
             let toSend: any[];
             if(this.preventEmptyParts) {
                 toSend = this.currentPartBlobs.slice(0, -1);

--- a/src/progressive-video-uploader.ts
+++ b/src/progressive-video-uploader.ts
@@ -43,6 +43,10 @@ export class ProgressiveUploader extends AbstractUploader<ProgressiveProgressEve
         if ((this.preventEmptyParts && (this.currentPartBlobsSize - file.size >= MIN_CHUNK_SIZE))
             || (!this.preventEmptyParts && (this.currentPartBlobsSize >= MIN_CHUNK_SIZE))
             || (!this.mergeSmallPartsBeforeUpload)) {
+
+            if (!this.mergeSmallPartsBeforeUpload && this.currentPartBlobsSize < MIN_CHUNK_SIZE) {
+                throw new Error(`Each part must have a minimal size of 5MB. The current part has a size of ${this.currentPartBlobsSize / 1024 / 1024}MB.`)
+            }
             let toSend: any[];
             if(this.preventEmptyParts) {
                 toSend = this.currentPartBlobs.slice(0, -1);


### PR DESCRIPTION
Add `mergeSmallPartsBeforeUpload` option to the ProgressiveUploader to let the user choose to merge parts smaller than 5MB.
In the case of `mergeSmallPartsBeforeUpload = false`, if the user sends a part smaller than 5MB, an error is thrown.